### PR TITLE
Remove mcpx version badge

### DIFF
--- a/mcpx/README.md
+++ b/mcpx/README.md
@@ -1,6 +1,4 @@
 <img src="./logo.png" width=150>
-[![version](https://img.shields.io/badge/version-1.2.3-green)](https://github.com/mcpx/mcpx/releases)
-
 
 ## Introduction
 


### PR DESCRIPTION
It can be added again if there would be a version releases mcpx, for now it doesn't have an independent version or release (on github). 