### PR TITLE
[mcpx] Normalize tool group service keys in permission lookup

### DIFF
--- a/mcpx/packages/mcpx-server/src/services/permissions.test.ts
+++ b/mcpx/packages/mcpx-server/src/services/permissions.test.ts
@@ -254,6 +254,56 @@ describe("PermissionManager#hasPermission", () => {
     });
   });
 
+  describe("when a tool group uses a non-normalized service key", () => {
+    const config: Config = {
+      ...DEFAULT_CONFIG,
+      permissions: {
+        default: {
+          _type: "default-block",
+          allow: [],
+        },
+        consumers: {
+          developers: {
+            _type: "default-block",
+            allow: ["read"],
+          },
+        },
+        clientNames: {},
+      },
+      toolGroups: [
+        { name: "read", services: { "  MyTeamHub  ": ["read-message"] } },
+      ],
+    };
+
+    it("returns true for allowed tool when request uses normalized service name", async () => {
+      const permissionManager = new PermissionManager(noOpLogger);
+      await permissionManager.prepareConfig(config);
+      await permissionManager.commitConfig();
+      expect(
+        permissionManager.hasPermission({
+          capabilityKind: "tools",
+          serviceName: "myteamhub",
+          capabilityName: "read-message",
+          consumerTag: "developers",
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false for a tool not in the group", async () => {
+      const permissionManager = new PermissionManager(noOpLogger);
+      await permissionManager.prepareConfig(config);
+      await permissionManager.commitConfig();
+      expect(
+        permissionManager.hasPermission({
+          capabilityKind: "tools",
+          serviceName: "myteamhub",
+          capabilityName: "send-message",
+          consumerTag: "developers",
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe("when a consumer is blocked via profile", () => {
     const config: Config = {
       ...DEFAULT_CONFIG,

--- a/mcpx/packages/mcpx-server/src/services/permissions.ts
+++ b/mcpx/packages/mcpx-server/src/services/permissions.ts
@@ -1,4 +1,5 @@
 import { ConfigConsumer } from "@mcpx/toolkit-core/config";
+import { normalizeServerName } from "@mcpx/toolkit-core/data";
 import { Logger } from "winston";
 import { Config } from "../model/config/config.js";
 import type {
@@ -90,15 +91,16 @@ class PermissionManagerState {
         );
       }
       Object.entries(toolGroup).forEach(([serviceName, serviceToolGroup]) => {
-        const current = services.get(serviceName);
+        const normalizedServiceName = normalizeServerName(serviceName);
+        const current = services.get(normalizedServiceName);
         if (!current) {
           services.set(
-            serviceName,
+            normalizedServiceName,
             buildServicePermissions(type, serviceToolGroup),
           );
         } else {
           services.set(
-            serviceName,
+            normalizedServiceName,
             mergeServicePermissions(
               current,
               buildServicePermissions(type, serviceToolGroup),


### PR DESCRIPTION
## Summary

Selective tool groups exposed zero tools to an agent even when the group contained tools. Root cause: tool groups authored via the UI/config store the server's **display name** (e.g. `MyTeamHub`) as the service key, but permission checks at request time use the **normalized** server name (lowercased/trimmed, e.g. `myteamhub`). The case-sensitive lookup missed, so every tool in the group was silently blocked.

Fix: normalize the service key with `normalizeServerName()` when building the permission map in `PermissionManagerState.addServices()`, so it matches the value `hasPermission()` receives from the capability resolver.

Fixes #68

## Changes

- `mcpx/packages/mcpx-server/src/services/permissions.ts`: normalize tool group service keys before storing them in the permission map.
- `mcpx/packages/mcpx-server/src/services/permissions.test.ts`: regression test covering a non-normalized (mixed-case, whitespace-padded) service key.

## Test plan

- [x] `permissions.test.ts` passes, including the new regression cases.
- [x] Verified end-to-end: a UI-created tool group assigned to an agent now exposes its tools instead of zero.

