### PR TITLE
mcpx: restrict DiskTokenStore files to the owner

### DIFF
--- a/mcpx/packages/mcpx-server/src/services/disk-token-store.test.ts
+++ b/mcpx/packages/mcpx-server/src/services/disk-token-store.test.ts
@@ -1,0 +1,95 @@
+import { noOpLogger } from "@mcpx/toolkit-core/logging";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { DiskTokenStore } from "./disk-token-store.js";
+
+// POSIX permission bits are not modelled on Windows, where `chmod` only
+// reflects the read-only flag, so these assertions are meaningless there.
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+const SERVER_NAME = "example-server";
+
+async function modeOf(p: string): Promise<number> {
+  return (await fs.stat(p)).mode & 0o777;
+}
+
+describePosix("DiskTokenStore file permissions", () => {
+  let baseDir: string;
+  let tokensDir: string;
+  let store: DiskTokenStore;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "disk-token-store-"));
+    tokensDir = path.join(baseDir, ".mcpx", "tokens");
+    store = new DiskTokenStore(tokensDir, noOpLogger);
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  async function writeAll(): Promise<void> {
+    await store.saveTokens(SERVER_NAME, {
+      access_token: "access-token",
+      token_type: "Bearer",
+      refresh_token: "refresh-token",
+    });
+    await store.saveCodeVerifier(SERVER_NAME, "code-verifier");
+    await store.saveClientInfo(SERVER_NAME, {
+      client_id: "client-id",
+      redirect_uris: ["http://localhost/callback"],
+    });
+  }
+
+  async function expectRestricted(): Promise<void> {
+    expect(await modeOf(tokensDir)).toBe(0o700);
+    const entries = await fs.readdir(tokensDir);
+    expect(entries.sort()).toEqual([
+      `${SERVER_NAME}-client.json`,
+      `${SERVER_NAME}-tokens.json`,
+      `${SERVER_NAME}-verifier.txt`,
+    ]);
+    for (const entry of entries) {
+      expect([entry, await modeOf(path.join(tokensDir, entry))]).toEqual([
+        entry,
+        0o600,
+      ]);
+    }
+  }
+
+  it("restricts the tokens directory and its files to the owner", async () => {
+    await writeAll();
+    await expectRestricted();
+  });
+
+  it("tightens a directory and files left over with lax permissions", async () => {
+    await fs.mkdir(tokensDir, { recursive: true });
+    await fs.chmod(tokensDir, 0o755);
+    for (const name of [
+      `${SERVER_NAME}-client.json`,
+      `${SERVER_NAME}-tokens.json`,
+      `${SERVER_NAME}-verifier.txt`,
+    ]) {
+      const p = path.join(tokensDir, name);
+      await fs.writeFile(p, "stale", "utf8");
+      await fs.chmod(p, 0o644);
+    }
+
+    await writeAll();
+    await expectRestricted();
+  });
+
+  it("still round-trips what it stored", async () => {
+    await writeAll();
+
+    expect(await store.loadTokens(SERVER_NAME)).toMatchObject({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+    });
+    expect(await store.loadCodeVerifier(SERVER_NAME)).toBe("code-verifier");
+    expect(await store.loadClientInfo(SERVER_NAME)).toMatchObject({
+      client_id: "client-id",
+    });
+  });
+});

--- a/mcpx/packages/mcpx-server/src/services/disk-token-store.ts
+++ b/mcpx/packages/mcpx-server/src/services/disk-token-store.ts
@@ -12,6 +12,12 @@ import {
   storedTokensSchema,
 } from "./oauth-token-store.js";
 
+// The token store holds OAuth access tokens, refresh tokens, PKCE code
+// verifiers and client credentials. They must not be readable by other local
+// users, so the directory and its files are restricted to the owner.
+const TOKENS_DIR_MODE = 0o700;
+const TOKEN_FILE_MODE = 0o600;
+
 export class DiskTokenStore implements OAuthTokenStoreI {
   private readonly tokensDir: string;
   private readonly logger: Logger;
@@ -104,8 +110,22 @@ export class DiskTokenStore implements OAuthTokenStoreI {
   }
 
   private async writeFile(p: string, content: string): Promise<void> {
-    await fs.mkdir(this.tokensDir, { recursive: true });
-    await fs.writeFile(p, content, "utf8");
+    await fs.mkdir(this.tokensDir, { recursive: true, mode: TOKENS_DIR_MODE });
+    // `mode` on `mkdir` only applies to directories it creates, and is masked
+    // by the process umask, so tighten explicitly to also cover a directory
+    // left behind by an earlier version.
+    await fs.chmod(this.tokensDir, TOKENS_DIR_MODE);
+
+    // Open (and truncate) before writing so the permissions can be tightened
+    // while the file is still empty. This also repairs files created by an
+    // earlier version, and is unaffected by the umask.
+    const handle = await fs.open(p, "w", TOKEN_FILE_MODE);
+    try {
+      await handle.chmod(TOKEN_FILE_MODE);
+      await handle.writeFile(content, "utf8");
+    } finally {
+      await handle.close();
+    }
   }
 
   private tokenPath(serverName: string): string {


### PR DESCRIPTION
Fixes #73

### What

`DiskTokenStore` wrote `.mcpx/tokens` and its contents with default filesystem
permissions. Under the common `umask 022` that produces a `0755` directory and
`0644` files, so OAuth access tokens, refresh tokens, PKCE `code_verifier`s and
client info were readable by any other local user.

Measured on Linux / Node 24 with `umask 022`:

| path | before | after |
| --- | --- | --- |
| `.mcpx/tokens/` | `0755` | `0700` |
| `<server>-tokens.json` | `0644` | `0600` |
| `<server>-verifier.txt` | `0644` | `0600` |
| `<server>-client.json` | `0644` | `0600` |

Scope: local exposure only, on hosts shared with other local accounts. Not
remotely exploitable, and not an issue on a single-user machine or a properly
isolated container. `mcp-remote` already writes its token files `0600`, so this
brings mcpx in line with the established convention.

### How

- `mkdir` with `mode: 0o700`, plus an explicit `chmod` on the tokens directory.
  `mode` only applies to directories the call actually creates and is masked by
  the umask, so the `chmod` is what repairs a directory left behind by an
  earlier version.
- Files are opened with `fs.open(p, "w", 0o600)` and `chmod`ed **before** the
  content is written. Passing `mode` to `writeFile` alone would not have
  covered a pre-existing `0644` file, and tightening after the write would
  leave a brief window where a token sits in a world-readable file.
- Only the leaf `tokens` directory is `chmod`ed. The parent `.mcpx` is left
  alone if it already exists; nothing else in the repo writes there.

### Tests

New `mcpx/packages/mcpx-server/src/services/disk-token-store.test.ts` (none
existed before) covering:

1. a fresh store produces a `0700` directory and `0600` files,
2. a directory and files left over at `0755`/`0644` are tightened on the next
   write,
3. the stored values still round-trip.

The suite is guarded with `process.platform === "win32" ? describe.skip :
describe`, since POSIX modes are not modelled on Windows.

Verified that tests 1 and 2 fail against `main` (`Expected: 448, Received: 493`)
and pass with this change.

### Verification

Run from `mcpx/packages/mcpx-server`, after `npm install` and
`node build-deps.cjs` at the `mcpx` root:

```
$ npm test
Test Suites: 47 passed, 47 total
Tests:       791 passed, 791 total
exit 0

$ npm run lint
exit 0

$ npm run typecheck
exit 0

$ npm run prettier
All matched files use Prettier code style!
exit 0
```

Integration tests (`it:run`) were not run; they need Docker and do not touch
this code path.
