### PR TITLE
Docs: optional TOA verify for MCPX governance

### DIFF
--- a/mcpx/README.md
+++ b/mcpx/README.md
@@ -26,6 +26,10 @@ MCPX provides:
 [![MCPX Demo Video](https://img.youtube.com/vi/5I23SiOflaM/0.jpg)](https://www.youtube.com/watch?v=5I23SiOflaM)
 </div>
 
+## Optional TOA governance gate
+
+Before enabling a new upstream MCP server in MCPX, you can optionally verify offline [TOA](https://github.com/Carmel-Labs-Inc/toa) delivery evidence. See [docs/toa-optional-governance-gate.md](docs/toa-optional-governance-gate.md).
+
 ## Tip
 This repository helps you get up and running quickly. For detailed feature guides, architecture, and advanced options, head to the [official docs](https://docs.lunar.dev/next/mcpx/get_started).
 

--- a/mcpx/docs/toa-optional-governance-gate.md
+++ b/mcpx/docs/toa-optional-governance-gate.md
@@ -11,7 +11,7 @@ delivery evidence before enabling a new upstream in MCPX.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/mcpx/docs/toa-optional-governance-gate.md
+++ b/mcpx/docs/toa-optional-governance-gate.md
@@ -1,0 +1,20 @@
+# Optional TOA verify for MCPX governance
+
+Lunar MCPX aggregates MCP servers with centralized governance and security.
+That answers unified access and policy. It does not prove tool delivery from an
+outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is optional offline
+delivery evidence before enabling a new upstream in MCPX.
+
+```yaml
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Example: [`../examples/toa-after-enable.yml`](../examples/toa-after-enable.yml).
+
+Not per-call. No AgentStatus account required to verify.

--- a/mcpx/docs/toa-optional-governance-gate.md
+++ b/mcpx/docs/toa-optional-governance-gate.md
@@ -11,8 +11,8 @@ delivery evidence before enabling a new upstream in MCPX.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Example: [`../examples/toa-after-enable.yml`](../examples/toa-after-enable.yml).

--- a/mcpx/examples/toa-after-enable.yml
+++ b/mcpx/examples/toa-after-enable.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/mcpx/examples/toa-after-enable.yml
+++ b/mcpx/examples/toa-after-enable.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/mcpx/examples/toa-after-enable.yml
+++ b/mcpx/examples/toa-after-enable.yml
@@ -1,0 +1,13 @@
+# Example only.
+name: MCPX enable and optional TOA
+on: [workflow_dispatch]
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` before enabling an upstream in Lunar MCPX.

- `mcpx/docs/toa-optional-governance-gate.md`
- `mcpx/examples/toa-after-enable.yml`
- MCPX README pointer

Does not change MCPX runtime. No AgentStatus account required to verify.

## Test plan

- [ ] Docs clearly optional
- [ ] Example YAML gated on `toa.json`

Made with [Cursor](https://cursor.com)