### PR TITLE
fix(mcpx): normalize tool-group service keys for permission matching (#68)

### DIFF
--- a/mcpx/packages/mcpx-server/src/services/permissions.test.ts
+++ b/mcpx/packages/mcpx-server/src/services/permissions.test.ts
@@ -254,6 +254,69 @@ describe("PermissionManager#hasPermission", () => {
     });
   });
 
+  describe("when tool-group service keys use display-case names (#68)", () => {
+    const config: Config = {
+      ...DEFAULT_CONFIG,
+      permissions: {
+        default: {
+          _type: "default-block",
+          allow: [],
+        },
+        consumers: {
+          agent: {
+            _type: "default-block",
+            allow: ["team-hub-read"],
+          },
+        },
+        clientNames: {},
+      },
+      toolGroups: [
+        {
+          name: "team-hub-read",
+          // Dashboard Create Tool Group stores the display name; capability
+          // resolution looks up the normalized lowercase form.
+          services: { MyTeamHub: ["list-items", "get-item"] },
+        },
+      ],
+    };
+
+    it("allows tools when the group key casing differs from the lookup name", async () => {
+      const permissionManager = new PermissionManager(noOpLogger);
+      await permissionManager.prepareConfig(config);
+      await permissionManager.commitConfig();
+      expect(
+        permissionManager.hasPermission({
+          capabilityKind: "tools",
+          serviceName: "myteamhub",
+          capabilityName: "list-items",
+          consumerTag: "agent",
+        }),
+      ).toBe(true);
+      expect(
+        permissionManager.hasPermission({
+          capabilityKind: "tools",
+          serviceName: "myteamhub",
+          capabilityName: "get-item",
+          consumerTag: "agent",
+        }),
+      ).toBe(true);
+    });
+
+    it("still blocks tools outside the allowed group", async () => {
+      const permissionManager = new PermissionManager(noOpLogger);
+      await permissionManager.prepareConfig(config);
+      await permissionManager.commitConfig();
+      expect(
+        permissionManager.hasPermission({
+          capabilityKind: "tools",
+          serviceName: "myteamhub",
+          capabilityName: "delete-item",
+          consumerTag: "agent",
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe("when a consumer is blocked via profile", () => {
     const config: Config = {
       ...DEFAULT_CONFIG,

--- a/mcpx/packages/mcpx-server/src/services/permissions.ts
+++ b/mcpx/packages/mcpx-server/src/services/permissions.ts
@@ -1,4 +1,5 @@
 import { ConfigConsumer } from "@mcpx/toolkit-core/config";
+import { normalizeServerName } from "@mcpx/toolkit-core/data";
 import { Logger } from "winston";
 import { Config } from "../model/config/config.js";
 import type {
@@ -90,15 +91,19 @@ class PermissionManagerState {
         );
       }
       Object.entries(toolGroup).forEach(([serviceName, serviceToolGroup]) => {
-        const current = services.get(serviceName);
+        // Tool-group configs may keep display-case server names (e.g. dashboard
+        // Create Tool Group), while capability resolution looks up the
+        // normalizeServerName()'d form. Normalize here so both agree (#68).
+        const normalizedServiceName = normalizeServerName(serviceName);
+        const current = services.get(normalizedServiceName);
         if (!current) {
           services.set(
-            serviceName,
+            normalizedServiceName,
             buildServicePermissions(type, serviceToolGroup),
           );
         } else {
           services.set(
-            serviceName,
+            normalizedServiceName,
             mergeServicePermissions(
               current,
               buildServicePermissions(type, serviceToolGroup),
@@ -211,7 +216,7 @@ function evaluatePermission(
   toolName: string,
 ): boolean {
   const { default: consumerDefault, services } = consumer;
-  const service = services.get(serviceName);
+  const service = services.get(normalizeServerName(serviceName));
   if (!service) {
     return consumerDefault === "allow";
   }


### PR DESCRIPTION
## Summary

Tool groups created from the dashboard can store server names in display case (e.g. `MyTeamHub`), while capability resolution looks up the `normalizeServerName()` form (`myteamhub`). Permission matching used the raw group key, so `default-block` consumers with a selective allow-group saw **0 tools**.

This normalizes service keys when building the permission map (and on lookup) so both sides agree.

Fixes #68

## Test plan

- [x] `npm test -- ./src/services/permissions.test.ts` in `mcpx/packages/mcpx-server` (full package suite green; new cases cover display-case group keys vs lowercase lookups)